### PR TITLE
Add pyOpenSSL 16.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN echo "root:P@ssw0rd@123" | chpasswd
 RUN apt-get update && \
     apt-get install python-setuptools python-dev build-essential -y && \
     easy_install pip && \
-    pip install ansible
+    pip install ansible && \
+    pip install pyOpenSSL==16.2.0
 
 # -----------------------------------------------------------
 


### PR DESCRIPTION
* Includes pypi installation of pyOpenSSL, version 16.2.0 in the Dockerfile.
* Test affiliated with this change can be found at https://hub.docker.com/r/fubarhouse/ansible-playable/builds/ 

Signed-off-by: Karl Hepworth <karl.hepworth@gmail.com>